### PR TITLE
Made deletion of members/professional accounts consistent 

### DIFF
--- a/app/controllers/business_professionals_controller.rb
+++ b/app/controllers/business_professionals_controller.rb
@@ -4,6 +4,8 @@ class BusinessProfessionalsController < ApplicationController
   before_action :set_business_professional, only: %i[show edit update destroy]
   before_action :admin?, only: [:destroy]
   before_action :allowed_to_view_bpro?, only: %i[show edit update]
+  before_action :business_member_event_delete, only: %i[destroy]
+  before_action :business_member_event_attendance_delete, only: %i[destroy]
   after_action :event_business_member_delete, only: %i[attended]
   # GET /business_professionals or /business_professionals.json
   def index
@@ -78,6 +80,16 @@ class BusinessProfessionalsController < ApplicationController
   def event_business_member_delete
     @event_business_members = EventBusinessProfessional.find_by(business_professional_id: params[:bid], event_id: params[:eid])
     @event_business_members.destroy!
+  end
+
+  def business_member_event_delete
+    @event_business_members = EventBusinessProfessional.where(business_professional_id: @business_professional.id)
+    @event_business_members.each(&:destroy)
+  end
+
+  def business_member_event_attendance_delete
+    @business_attendances = BusinessAttendance.where(business_professional_id: @business_professional.id)
+    @business_attendances.each(&:destroy)
   end
 
   # DELETE /business_professionals/1 or /business_professionals/1.json

--- a/app/controllers/student_members_controller.rb
+++ b/app/controllers/student_members_controller.rb
@@ -6,6 +6,8 @@ class StudentMembersController < ApplicationController
   before_action :allowed_to_view_student?, only: %i[edit update dashboard]
   before_action :allowed_to_view_student_info?, only: [:show]
   before_action :points_add, only: %i[eventcode]
+  before_action :student_member_event_delete, only: %i[destroy]
+  before_action :student_event_attendance_delete, only: %i[destroy]
   after_action :attended, only: %i[eventcode]
   after_action :event_student_member_delete, only: %i[eventcode]
   after_action :req_points, only: %i[index]
@@ -166,6 +168,16 @@ class StudentMembersController < ApplicationController
         format.html { redirect_to(events_student_member_path(@student_member), notice: 'Incorrect Code entered') }
       end
     end
+  end
+
+  def student_member_event_delete
+    @event_student_members = EventStudentMember.where(student_member_id: @student_member.id)
+    @event_student_members.each(&:destroy)
+  end
+
+  def student_event_attendance_delete
+    @member_attendances = MemberAttendance.where(student_member_id: @student_member.id)
+    @member_attendances.each(&:destroy)
   end
 
   # DELETE /student_members/1 or /student_members/1.json


### PR DESCRIPTION
When a member or professional is deleted, the associated join table entries are now deleted. This change was added so that there are no errors when trying to pull entries from join tables as the join tables depend on the existence of members/professionals.